### PR TITLE
Hide Classes - Responsive

### DIFF
--- a/primeflex.css
+++ b/primeflex.css
@@ -125,6 +125,9 @@
   -ms-grid-row-align: stretch;
   align-self: stretch; }
 
+.p-col-hide {
+  display: none; }
+
 .p-col-1,
 .p-col-2,
 .p-col-3,
@@ -139,6 +142,7 @@
 .p-col-12 {
   -webkit-box-flex: 0;
   -ms-flex: 0 0 auto;
+  display: block;
   flex: 0 0 auto;
   padding: 0.5em; }
 
@@ -271,6 +275,9 @@
   padding: 0; }
 
 @media screen and (min-width: 576px) {
+  .p-sm-hide {
+    display: none; }
+
   .p-sm-1,
   .p-sm-2,
   .p-sm-3,
@@ -285,6 +292,7 @@
   .p-sm-12 {
     -webkit-box-flex: 0;
     -ms-flex: 0 0 auto;
+    display: block;
     flex: 0 0 auto; }
 
   .p-sm-1 {
@@ -362,6 +370,9 @@
   .p-sm-offset-0 {
     margin-left: 0%; } }
 @media screen and (min-width: 768px) {
+  .p-md-hide {
+    display: none; }
+
   .p-md-1,
   .p-md-2,
   .p-md-3,
@@ -376,6 +387,7 @@
   .p-md-12 {
     -webkit-box-flex: 0;
     -ms-flex: 0 0 auto;
+    display: block;
     flex: 0 0 auto; }
 
   .p-md-1 {
@@ -453,6 +465,9 @@
   .p-md-offset-0 {
     margin-left: 0%; } }
 @media screen and (min-width: 992px) {
+  .p-lg-hide {
+    display: none; }
+
   .p-lg-1,
   .p-lg-2,
   .p-lg-3,
@@ -467,6 +482,7 @@
   .p-lg-12 {
     -webkit-box-flex: 0;
     -ms-flex: 0 0 auto;
+    display: block;
     flex: 0 0 auto; }
 
   .p-lg-1 {
@@ -544,6 +560,9 @@
   .p-lg-offset-0 {
     margin-left: 0%; } }
 @media screen and (min-width: 1200px) {
+  .p-xl-hide {
+    display: none; }
+
   .p-xl-1,
   .p-xl-2,
   .p-xl-3,
@@ -558,6 +577,7 @@
   .p-xl-12 {
     -webkit-box-flex: 0;
     -ms-flex: 0 0 auto;
+    display: block;
     flex: 0 0 auto; }
 
   .p-xl-1 {

--- a/primeflex.scss
+++ b/primeflex.scss
@@ -155,6 +155,10 @@ $gutter:.5em;
     align-self: stretch;
 }
 
+.p-col-hide {
+    display: none;
+}
+
 .p-col-1,
 .p-col-2,
 .p-col-3,
@@ -169,6 +173,7 @@ $gutter:.5em;
 .p-col-12 {
     -webkit-box-flex: 0;
     -ms-flex: 0 0 auto;
+    display: block;
     flex: 0 0 auto;
     padding: $gutter;
 }
@@ -330,6 +335,10 @@ $gutter:.5em;
 
 @media screen and (min-width: $sm) {
 
+    .p-sm-hide {
+        display: none;
+    }
+
     .p-sm-1,
     .p-sm-2,
     .p-sm-3,
@@ -344,6 +353,7 @@ $gutter:.5em;
     .p-sm-12 {
         -webkit-box-flex: 0;
         -ms-flex: 0 0 auto;
+        display: block;
         flex: 0 0 auto;
     }
 
@@ -450,6 +460,10 @@ $gutter:.5em;
 
 @media screen and (min-width: $md) {
 
+    .p-md-hide {
+        display: none;
+    }
+
     .p-md-1,
     .p-md-2,
     .p-md-3,
@@ -464,6 +478,7 @@ $gutter:.5em;
     .p-md-12 {
         -webkit-box-flex: 0;
         -ms-flex: 0 0 auto;
+        display: block;
         flex: 0 0 auto;
     }
 
@@ -570,6 +585,10 @@ $gutter:.5em;
 
 @media screen and (min-width: $lg) {
 
+    .p-lg-hide {
+        display: none;
+    }
+
     .p-lg-1,
     .p-lg-2,
     .p-lg-3,
@@ -584,6 +603,7 @@ $gutter:.5em;
     .p-lg-12 {
         -webkit-box-flex: 0;
         -ms-flex: 0 0 auto;
+        display: block;
         flex: 0 0 auto;
     }
 
@@ -690,6 +710,10 @@ $gutter:.5em;
 
 @media screen and (min-width: $xl) {
 
+    .p-xl-hide {
+        display: none;
+    }
+
     .p-xl-1,
     .p-xl-2,
     .p-xl-3,
@@ -704,6 +728,7 @@ $gutter:.5em;
     .p-xl-12 {
         -webkit-box-flex: 0;
         -ms-flex: 0 0 auto;
+        display: block;
         flex: 0 0 auto;
     }
 


### PR DESCRIPTION
Added classes to hide elements for mobile responsive.
Some elements need to be hidden for mobile view. These classes will be able to trigger the same.

Classe Names:
`.p-col-hide`
`.p-sm-hide` - For small devices
`.p-md-hide` - For medium devices
`.p-lg-hide` - For large devices
`.p-xl-hide` - For very large devices
