### PR TITLE
Allow for overriding breakpoints

### DIFF
--- a/_sass/lib/src/_variables.scss
+++ b/_sass/lib/src/_variables.scss
@@ -13,8 +13,8 @@ $helperTextMargin: .25rem !default;
 $spacer:1rem !default;
 
 $breakpoints: (
-    'sm': 576px,
-    'md': 768px,
-    'lg': 992px,
-    'xl': 1200px
-);
+    'sm': $sm,
+    'md': $md,
+    'lg': $lg,
+    'xl': $xl
+) !default;


### PR DESCRIPTION
1. Use the breakpoint variables in the breakpoint map to allow overriding existing breakpoint values
2. Add `!default` to the breakpoints map to allow for adding/removing breakpoints