### PR TITLE
Make $breakpoints as default value

### DIFF
--- a/_sass/lib/src/_variables.scss
+++ b/_sass/lib/src/_variables.scss
@@ -13,8 +13,8 @@ $helperTextMargin: .25rem !default;
 $spacer:1rem !default;
 
 $breakpoints: (
-    'sm': 576px,
-    'md': 768px,
-    'lg': 992px,
-    'xl': 1200px
-);
+    'sm': $sm,
+    'md': $md,
+    'lg': $lg,
+    'xl': $xl
+) !default;


### PR DESCRIPTION
Fixes #111 (that breakpoints variable cannot be overridden).