### PR TITLE
(Docs) Update border-100 class name previously incorrectly named as border-200

### DIFF
--- a/components/doc/bordercolor/classesdoc.js
+++ b/components/doc/bordercolor/classesdoc.js
@@ -60,7 +60,7 @@ export function ClassesDoc(props) {
                             <td>border-100</td>
                             <td>border-color: var(--surface-100);</td>
                             <td>
-                                <div className="border-200 border-2 shadow-1" style={{ width: '50px', height: '20px' }}></div>
+                                <div className="border-100 border-2 shadow-1" style={{ width: '50px', height: '20px' }}></div>
                             </td>
                         </tr>
                         <tr>

--- a/components/doc/bordercolor/classesdoc.js
+++ b/components/doc/bordercolor/classesdoc.js
@@ -57,7 +57,7 @@ export function ClassesDoc(props) {
                             </td>
                         </tr>
                         <tr>
-                            <td>border-200</td>
+                            <td>border-100</td>
                             <td>border-color: var(--surface-100);</td>
                             <td>
                                 <div className="border-200 border-2 shadow-1" style={{ width: '50px', height: '20px' }}></div>


### PR DESCRIPTION
The fix contains updating the border-100 class name in the table and in the div section to correctly reflect border-100. It was previously incorrectly named border-200 which resulted in two border-200 instances in the docs.

![image](https://github.com/primefaces/primeflex/assets/49275204/8cc9d653-7324-47e6-aa27-26fbc520a43d)
