### PR TITLE
Fix: wrong class names/properties for flex-shrink

### DIFF
--- a/components/doc/flexshrink/classesdoc.js
+++ b/components/doc/flexshrink/classesdoc.js
@@ -14,12 +14,12 @@ export function ClassesDoc(props) {
                     </thead>
                     <tbody>
                         <tr>
-                            <td>flex-grow-0</td>
-                            <td>flex-grow: 0;</td>
+                            <td>flex-shrink-0</td>
+                            <td>flex-shrink: 0;</td>
                         </tr>
                         <tr>
-                            <td>flex-grow-1</td>
-                            <td>flex-grow: 1;</td>
+                            <td>flex-shrink-1</td>
+                            <td>flex-shrink: 1;</td>
                         </tr>
                     </tbody>
                 </table>


### PR DESCRIPTION
The classes table for the `flex-shrink` page shows the class names/properties for `flex-grow`.