### PR TITLE
fix: typo zoomninright

### DIFF
--- a/components/doc/animations/classesdoc.js
+++ b/components/doc/animations/classesdoc.js
@@ -582,12 +582,12 @@ export function ClassesDoc(props) {
                             </td>
                         </tr>
                         <tr>
-                            <td>zoomninright</td>
+                            <td>zoominright</td>
                             <td>
-                                animation: zoomninright .15s linear;
+                                animation: zoominright .15s linear;
                                 <br />
                                 <br />
-                                @keyframes zoomninright {'{'}
+                                @keyframes zoominright {'{'}
                                 <br />
                                 &emsp;0% {'{'}
                                 <br />

--- a/components/doc/animations/zoominrightdoc.js
+++ b/components/doc/animations/zoominrightdoc.js
@@ -1,11 +1,11 @@
 import { DocSectionCode } from '../common/docsectioncode';
 import { DocSectionText } from '../common/docsectiontext';
 
-export function ZoomninrightDoc(props) {
+export function ZoominrightDoc(props) {
     const code = `<div class="flex flex-wrap align-items-center justify-content-center">
-    <div class="zoomninright animation-duration-1000 animation-iteration-infinite flex align-items-center justify-content-center
+    <div class="zoominright animation-duration-1000 animation-iteration-infinite flex align-items-center justify-content-center
         font-bold bg-primary border-round m-2 px-5 py-3">
-        zoomninright
+        zoominright
     </div>
 </div>
 `;
@@ -16,10 +16,10 @@ export function ZoomninrightDoc(props) {
             <div className="card">
                 <div className="flex flex-wrap align-items-center justify-content-center">
                     <div
-                        className="zoomninright animation-duration-1000 animation-iteration-infinite flex align-items-center justify-content-center
+                        className="zoominright animation-duration-1000 animation-iteration-infinite flex align-items-center justify-content-center
                         font-bold bg-primary border-round m-2 px-5 py-3"
                     >
-                        zoomninright
+                        zoominright
                     </div>
                 </div>
             </div>

--- a/pages/animations/index.js
+++ b/pages/animations/index.js
@@ -23,9 +23,9 @@ import { ZoominDoc } from '../../components/doc/animations/zoomindoc';
 import { ZoomindownDoc } from '../../components/doc/animations/zoomindowndoc';
 import { ZoominleftDoc } from '../../components/doc/animations/zoominleftdoc';
 import { ZoominupDoc } from '../../components/doc/animations/zoominupdoc';
-import { ZoomninrightDoc } from '../../components/doc/animations/zoomninrightdoc';
 import { DocSectionNav } from '../../components/doc/common/docsectionnav';
 import { DocSections } from '../../components/doc/common/docsections';
+import { ZoominrightDoc } from '../../components/doc/animations/zoominrightdoc';
 
 const PositionPage = () => {
     const docs = [
@@ -140,9 +140,9 @@ const PositionPage = () => {
             component: ZoominleftDoc
         },
         {
-            id: 'zoomninright',
-            label: 'zoomninright',
-            component: ZoomninrightDoc
+            id: 'zoominright',
+            label: 'zoominright',
+            component: ZoominrightDoc
         },
         {
             id: 'zoominup',


### PR DESCRIPTION
Fix #192 

Modified typo in all files: `zoominright` instead `zoomninright` (**extra N**).